### PR TITLE
Fix G115 false positive

### DIFF
--- a/analyzers/conversion_overflow.go
+++ b/analyzers/conversion_overflow.go
@@ -312,7 +312,13 @@ func getResultRange(ifInstr *ssa.If, instr *ssa.Convert, visitedIfs map[*ssa.If]
 	cond := ifInstr.Cond
 	binOp, ok := cond.(*ssa.BinOp)
 	if !ok || !isRangeCheck(binOp, instr.X) {
-		return rangeResult{minValue: math.MinInt, maxValue: math.MaxUint}
+		thenBounds := walkBranchForConvert(ifInstr.Block().Succs[0], instr, visitedIfs)
+		elseBounds := walkBranchForConvert(ifInstr.Block().Succs[1], instr, visitedIfs)
+		return rangeResult{
+			minValue:     math.MinInt,
+			maxValue:     math.MaxUint,
+			convertFound: thenBounds.convertFound || elseBounds.convertFound,
+		}
 	}
 
 	result := rangeResult{

--- a/testutils/g115_samples.go
+++ b/testutils/g115_samples.go
@@ -117,7 +117,7 @@ func main() {
 	`}, 1, gosec.NewConfig()},
 	{[]string{
 		`
-package main
+        package main
 
 import (
 	"fmt"
@@ -861,5 +861,23 @@ func main() {
             fmt.Printf("%d\n", b)
         }
 	`,
+	}, 0, gosec.NewConfig()},
+	{[]string{
+		`
+package main
+
+func main() {
+    var x int32
+    switch {
+    case x > 0:
+        switch {
+        case true:
+            f(uint64(x))
+        }
+    }
+}
+
+func f(_ uint64) {}
+                `,
 	}, 0, gosec.NewConfig()},
 }


### PR DESCRIPTION
## Summary
- fix false positive when conversion occurs under an unrelated `if`
- add regression test sample for G115

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68428ee52dd08323aeda95d37235cce9